### PR TITLE
Exclude key only if it is undefined, not falsy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ function applyRef (e, ref) {
 function ensureAttrs (objs) {
   const { attrs, events, ref, key, ...props } = objs || {};
   const newRef = ensureRef({ attrs, events, props, ref });
-  return { ref: newRef, ...(key ? { key } : {}) }
+  return { ref: newRef, ...(key !== undefined ? { key } : {}) }
 }
 
 // Ensures a ref is supplied that set each member appropriately and that

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ function applyRef (e, ref) {
 function ensureAttrs (objs) {
   const { attrs, events, ref, key, ...props } = objs || {};
   const newRef = ensureRef({ attrs, events, props, ref });
-  return { ref: newRef, ...(key !== undefined ? { key } : {}) }
+  return { ref: newRef, key }
 }
 
 // Ensures a ref is supplied that set each member appropriately and that

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -19,7 +19,7 @@ describe('Val', () => {
 
     const props = args[1];
 
-    expect(Object.getOwnPropertyNames(props).length).toBe(1);
+    expect(Object.getOwnPropertyNames(props)).toInclude('ref');
     expect(props.ref).toBeA('function');
   });
 


### PR DESCRIPTION
When iterating over an array, many people use the array index as the key value. This means that `0` must be accepted as a value of key to pass through.